### PR TITLE
Added repository namespace getter to ImmutableEncodedRepository

### DIFF
--- a/src/main/java/com/cloudogu/scm/el/env/ImmutableEncodedRepository.java
+++ b/src/main/java/com/cloudogu/scm/el/env/ImmutableEncodedRepository.java
@@ -57,6 +57,10 @@ public final class ImmutableEncodedRepository {
     return repository.getName();
   }
 
+  public String getNamespace() {
+    return repository.getNamespace();
+  }
+
   public String getType() {
     return repository.getType();
   }


### PR DESCRIPTION
## Proposed changes

The webhook plugin is currently missing the ability to retrieve the **namespace of a repository**, which can be very useful to be given as parameters of a webhook url for additional processing. It was suggested in [this conversation](https://community.cloudogu.com/t/webhook-plugin-unable-to-retrieve-namespace-of-repository/831/2?u=guntrumm) that I should propose a pull request with the needed changes.

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available
